### PR TITLE
Make systemd optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ LDFLAGS += -lm
 
 SERVER_CFLAGS := $(shell $(PKG_CONFIG) --cflags libsystemd)
 SERVER_LDFLAGS := $(shell $(PKG_CONFIG) --libs libsystemd)
+SERVER_CFLAGS += $(if $(SERVER_LDFLAGS), -DHAVE_SYSTEMD)
 
 COMPILE.c = $(CC) $(DEPFLAGS) $(CFLAGS) -c
 

--- a/server/log.c
+++ b/server/log.c
@@ -8,7 +8,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <syslog.h>
+
+#ifdef HAVE_SYSTEMD
 #include <systemd/sd-journal.h>
+#endif
 
 #include "log.h"
 
@@ -53,6 +57,7 @@ void log_msg(log_level_t level, const char *fmt, ...) {
     char buf[1024];
     vsnprintf(buf, sizeof(buf), fmt, args);
 
+#ifdef HAVE_SYSTEMD
     int priority = LOG_INFO;
     switch (level) {
       case LOG_LEVEL_ERROR: priority = LOG_ERR; break;
@@ -62,6 +67,7 @@ void log_msg(log_level_t level, const char *fmt, ...) {
     }
 
     sd_journal_print(priority, "%s", buf);
+#endif
   } else {
     FILE *out = level <= LOG_LEVEL_WARNING ? stderr : stdout;
     vfprintf(out, fmt, args);


### PR DESCRIPTION
Systemd is used for logging purposes and autostarting the service. For logging, the code actually already has a fallback for printing to stdout/stderr which will work fine for systems without systemd. It is easy to redirect that output to syslog or wherever desired. As for autostarting the server on device connection, non-systemd systems would need some kind of dynamic event logic to handle it. That would ultimately be up to the service manager to implement, but just running the service manually and/or adding to the initial startup services works fine for most usecases. So just guard the systemd stuff so it can compile. Fixes #4.